### PR TITLE
Correção no crash ao pressionar botão de galeria na tela de Editar Pe…

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,16 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,8 +7,6 @@
         android:required="true" />
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/aulawhatsapp/PerfilActivity.kt
+++ b/app/src/main/java/com/example/aulawhatsapp/PerfilActivity.kt
@@ -1,11 +1,9 @@
 package com.example.aulawhatsapp
 
-import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Bundle
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import com.example.aulawhatsapp.databinding.ActivityPerfilBinding
 import com.example.aulawhatsapp.utils.exibirMensagens
 
@@ -14,11 +12,9 @@ class PerfilActivity : AppCompatActivity() {
     private val binding by lazy {
         ActivityPerfilBinding.inflate(layoutInflater)
     }
-    private var temPermissaoCamera = false
-    private var temPermissaoGaleria = false
 
     private val gerenciadorGaleria = registerForActivityResult(
-        ActivityResultContracts.GetContent()
+        ActivityResultContracts.PickVisualMedia()
     ) { uri ->
         if (uri != null) {
             binding.imagePerfil.setImageURI(uri)
@@ -33,58 +29,13 @@ class PerfilActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         inicializarToolbar()
-        solicitarPermissoes()
         inicializarEventosCliques()
     }
 
     private fun inicializarEventosCliques() {
         binding.fabSelecionar.setOnClickListener {
-            if (temPermissaoGaleria) {
-                gerenciadorGaleria.launch("image/*")
-            } else {
-                exibirMensagens("Não tem permissão para acessar galeria")
-                solicitarPermissoes()
-            }
+            gerenciadorGaleria.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
         }
-    }
-    private fun solicitarPermissoes() {
-
-        //Verifico se usuário já tem permissão
-        temPermissaoCamera = ContextCompat.checkSelfPermission(
-            this,
-            Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
-
-        temPermissaoGaleria = ContextCompat.checkSelfPermission(
-            this,
-            Manifest.permission.READ_MEDIA_IMAGES
-        ) == PackageManager.PERMISSION_GRANTED
-
-        //LISTA DE PERMISSÕES NEGADAS
-        val listaPermissoesNegadas = mutableListOf<String>()
-        if( !temPermissaoCamera )
-            listaPermissoesNegadas.add( Manifest.permission.CAMERA )
-        if( !temPermissaoGaleria )
-            listaPermissoesNegadas.add( Manifest.permission.READ_MEDIA_IMAGES )
-
-        if( listaPermissoesNegadas.isNotEmpty() ){
-
-            //Solicitar multiplas permissões
-            val gerenciadorPermissoes = registerForActivityResult(
-                ActivityResultContracts.RequestMultiplePermissions()
-            ){ permissoes ->
-
-                temPermissaoCamera = permissoes[Manifest.permission.CAMERA]
-                    ?: temPermissaoCamera
-
-                temPermissaoGaleria = permissoes[Manifest.permission.READ_MEDIA_IMAGES]
-                    ?: temPermissaoGaleria
-
-            }
-            gerenciadorPermissoes.launch( listaPermissoesNegadas.toTypedArray() )
-
-        }
-
     }
 
     private fun inicializarToolbar() {


### PR DESCRIPTION
Olá @HSanttus ,
O crash ocorria pq a solicitação de permissão estava dentro de um "clickListener".
Além disso, percebi que o target do seu projeto é o Android 14.
Então, não é necessário solicitar:

1. Permissão de Câmera, pq segundo o código so solicitar q o usuário selecione uma foto em sua própria galeria;
2. Permissão de galeria, pq segundo a documentação do Android, a partir Android 14 o programador so precisa chamar um componente do próprio Android, que dará ao usuário a possibilidade de selecionar a imagem/vídeo que ele deseja compartilhar com o app. Logo, o app não terá acesso à toda galeria do usuário, mas sim à imagem/vídeo que o usuário selecionar.

Fonte: https://developer.android.com/about/versions/14/changes/partial-photo-video-access
Componente:  https://developer.android.com/training/data-storage/shared/photopicker